### PR TITLE
relabelled sensors, display top left of editor

### DIFF
--- a/blocks_vertical/mv2.js
+++ b/blocks_vertical/mv2.js
@@ -712,7 +712,7 @@ Blockly.Blocks['mv2_playSound'] = {
 
 // SENSING
 
-Blockly.Blocks['mv2_batteryLevel'] = {
+Blockly.Blocks['BatteryPercentage'] = {
   /**
    * Block to display Marty's battery percentage
    * @this Blockly.Block
@@ -739,7 +739,7 @@ Blockly.Blocks['mv2_batteryLevel'] = {
   }
 };
 
-Blockly.Blocks['mv2_position'] = {
+Blockly.Blocks['ServoPosition'] = {
   /**
    * Block to display the position of one of Marty's servos
    * @this Blockly.Block
@@ -781,7 +781,7 @@ Blockly.Blocks['mv2_position'] = {
   }
 };
 
-Blockly.Blocks['mv2_current'] = {
+Blockly.Blocks['ServoCurrent'] = {
   /**
    * Block to display the current through one of Marty's servos
    * @this Blockly.Block
@@ -823,7 +823,7 @@ Blockly.Blocks['mv2_current'] = {
   }
 };
 
-Blockly.Blocks['mv2_accelerometerX'] = {
+Blockly.Blocks['XAxisMovement'] = {
   /**
    * Block to display Marty's accelerometer X-axis state
    * @this Blockly.Block
@@ -850,7 +850,7 @@ Blockly.Blocks['mv2_accelerometerX'] = {
   }
 };
 
-Blockly.Blocks['mv2_accelerometerY'] = {
+Blockly.Blocks['YAxisMovement'] = {
   /**
    * Block to display Marty's accelerometer Y-axis state
    * @this Blockly.Block
@@ -877,7 +877,7 @@ Blockly.Blocks['mv2_accelerometerY'] = {
   }
 };
 
-Blockly.Blocks['mv2_accelerometerZ'] = {
+Blockly.Blocks['ZAxisMovement'] = {
   /**
    * Block to display Marty's accelerometer Z-axis state
    * @this Blockly.Block


### PR DESCRIPTION
### Resolves

https://robotical.atlassian.net/browse/M20-664

### Proposed Changes

Moves sensor display to the top left of the editor. Sensors are more clearly labelled, including distinct labels for individual servos. Sensor blocks stack vertically, and are still activated by the check box in the toolbox - primarily to prioritise a working solution in the short term.

### Reason for Changes

Sensor data initially appeared in the stage, which is now not guaranteed to be visible.

### Test Coverage

n/a